### PR TITLE
Suppress warnings when called CHOICE with undefined value

### DIFF
--- a/lib/Kossy/Validator.pm
+++ b/lib/Kossy/Validator.pm
@@ -16,6 +16,7 @@ our %VALIDATOR = (
     },
     CHOICE => sub {
         my ($req, $val, @args) = @_;
+        return if not defined($val);
         for my $c (@args) {
             if ($c eq $val) {
                 return 1;


### PR DESCRIPTION
Validator warns much when using GrowthForecast. So suppressed it.
